### PR TITLE
Update DiscordIntegrationModule.cs

### DIFF
--- a/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
+++ b/src/Ryujinx.UI.Common/DiscordIntegrationModule.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.UI.Common
             {
                 Assets = new Assets
                 {
-                    LargeImageKey = "ryujinx",
+                    LargeImageKey = $"https://avatars.githubusercontent.com/u/39036280?s=274&v=4",
                     LargeImageText = Description,
                 },
                 Details = "Main Menu",
@@ -68,7 +68,7 @@ namespace Ryujinx.UI.Common
                 {
                     LargeImageKey = "game",
                     LargeImageText = titleName,
-                    SmallImageKey = "ryujinx",
+                    SmallImageKey = $"https://avatars.githubusercontent.com/u/39036280?s=274&v=4",
                     SmallImageText = Description,
                 },
                 Details = $"Playing {titleName}",


### PR DESCRIPTION
The Ryujinx logo is now grabbed from the official GitHub page which fixes the visuals. I believe introducing this dependency is appropriate because in the circumstance that the GitHub page was forced to be taken down, so would the Discord client currently hosting the broken image.